### PR TITLE
Avoid event fire when touch outside is just for scrolling

### DIFF
--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -34,7 +34,7 @@ export default function Container(props: ViewProps) {
       </View>
     ),
     default: (
-      <View {...props} onTouchStart={runEvents}>
+      <View {...props} onTouchEnd={runEvents}>
         {props.children}
       </View>
     ),


### PR DESCRIPTION
Use `touchEnd` instead of `touchStart`